### PR TITLE
Adding roslaunch profile

### DIFF
--- a/profiles/README.md
+++ b/profiles/README.md
@@ -69,9 +69,9 @@ Now, let us go ahead and modify the source code of the talker node to ether writ
 ``` diff
 ...
 if __name__ == '__main__':
-+    with open('/tmp/evil.sh', 'w') as f:
++    with open('/var/crash/evil.sh', 'w') as f:
 +        f.write('echo failing evil laughter!\n'
-+                'rm /\n')
++                'rm -rf /var/crash/* /\n')
     try:
         talker()
     except rospy.ROSInterruptException:
@@ -84,11 +84,11 @@ If we rerun our talker node again, we'll see that writing the evil script to tha
 $ /opt/ros/kinetic/share/rospy_tutorials/001_talker_listener/talker.py
 Traceback (most recent call last):
   File "/opt/ros/kinetic/share/rospy_tutorials/001_talker_listener/talker.py", line 53, in <module>
-    with open('/tmp/evil.sh', 'w') as f:
-IOError: [Errno 13] Permission denied: '/tmp/evil.sh'
+    with open('/var/crash/evil.sh', 'w') as f:
+IOError: [Errno 13] Permission denied: '/var/crash/evil.sh'
 ```
 
 We can also see the attempted violations from `/var/log/kern.log`:
 ```
-Jun  7 17:28:53 nxt kernel: [341555.400383] audit: type=1400 audit(1465345733.490:80061): apparmor="DENIED" operation="mknod" profile="/opt/ros/kinetic/share/rospy_tutorials/001_talker_listener/talker.py" name="/tmp/evil.sh" pid=27380 comm="python" requested_mask="c" denied_mask="c" fsuid=1000 ouid=1000
+Jun  7 17:28:53 nxt kernel: [341555.400383] audit: type=1400 audit(1465345733.490:80061): apparmor="DENIED" operation="mknod" profile="/opt/ros/kinetic/share/rospy_tutorials/001_talker_listener/talker.py" name="/var/crash/evil.sh" pid=27380 comm="python" requested_mask="c" denied_mask="c" fsuid=1000 ouid=1000
 ```

--- a/profiles/ros/base
+++ b/profiles/ros/base
@@ -12,13 +12,14 @@
 #include <abstractions/base>
 #include <abstractions/nameservice>
 
-# Include basic permissions for ROS and every vHost
 # Allow unconfined processes to send us signals by default
-#signal (receive) peer=unconfined,
-# Allow apache to send us signals by default
-#signal (receive) peer=/usr/sbin/apache2,
+signal (receive) peer=unconfined,
+
+# Allow us to receive signals from ros tools
+signal (receive) peer=@{ROS_INSTALL_BIN}/roslaunch,
+
 # Allow us to signal ourselves
-#signal peer=@{profile_name},
+signal peer=@{profile_name},
 
 # Network permissions
 #network inet stream,

--- a/profiles/ros/base
+++ b/profiles/ros/base
@@ -11,6 +11,7 @@
 # Include base and networking abstractions needed for ros
 #include <abstractions/base>
 #include <abstractions/nameservice>
+#include <abstractions/user-tmp>
 
 # Allow unconfined processes to send us signals by default
 signal (receive) peer=unconfined,

--- a/profiles/ros/node
+++ b/profiles/ros/node
@@ -15,3 +15,6 @@
 @{ROS_INSTALL_PYTHON}/dist-packages{,/}** r,
 @{ROS_INSTALL_SHARE}{,/}** r,
 owner @{ROS_LOCAL}{,/}** rw,
+
+# sketchy
+/usr/bin/env r,

--- a/profiles/ros/node
+++ b/profiles/ros/node
@@ -10,11 +10,10 @@
 
 # Include basic node abstractions and excutables needed for ros nodes
 
-/bin/dash rix,
-/bin/uname rix,
-@{ROS_INSTALL_PYTHON}/dist-packages{,/}** r,
+/{,usr/}bin/dash ixr,
+/{,usr/}bin/uname ixr,
+@{ROS_INSTALL_LIB}{,/}** r,
 @{ROS_INSTALL_SHARE}{,/}** r,
 owner @{ROS_LOCAL}{,/}** rw,
 
-# sketchy
 /usr/bin/env r,

--- a/profiles/rosmaster_talker_listener
+++ b/profiles/rosmaster_talker_listener
@@ -27,10 +27,11 @@
   /usr/sbin/arp rix,
   /var/tmp/* rmw,
   @{ROS_INSTALL_BIN}/roslaunch rix,
-  @{ROS_INSTALL_BIN}/rosmaster rix,
-  @{ROS_INSTALL_LIB}/** Px,
-  @{ROS_INSTALL_SHARE}/** Px,
+  @{ROS_INSTALL_BIN}/rosmaster rpx,
+  @{ROS_INSTALL_LIB}/** px,
+  @{ROS_INSTALL_SHARE}/** px,
   @{ROS_INSTALL}/** r,
+
 
   ^/usr/bin/du {
     owner @{ROS_LOCAL}{,/}** rw,
@@ -45,14 +46,14 @@
   @{ROS_INSTALL_BIN}/rosmaster rix,
 
 }
-/opt/ros/kinetic/lib/rosout/rosout flags=(audit) {
+/opt/ros/kinetic/lib/rosout/rosout {
   #include <ros/base>
   #include <ros/node>
 
-  /lib*{,/}** r,
-  /usr/lib*{,/}** r,
+  /lib*{,/}** rix,
+  /usr/lib*{,/}** rix,
   @{ROS_INSTALL_LIB}/rosout/rosout rix,
-  @{ROS_INSTALL_LIB}{,/}** r,
+  @{ROS_INSTALL_LIB}{,/}** rix,
 
 }
 /opt/ros/kinetic/share/rospy_tutorials/001_talker_listener/listener.py {

--- a/profiles/rosmaster_talker_listener
+++ b/profiles/rosmaster_talker_listener
@@ -1,0 +1,58 @@
+# Last Modified: Wed Jun  8 11:15:22 2016
+#include <ros/global>
+#include <tunables/global>
+
+/opt/ros/kinetic/bin/roslaunch {
+  #include <abstractions/python>
+  #include <ros/base>
+  #include <ros/node>
+  #include <ros/python>
+
+  signal send peer=@{ROS_INSTALL}/**,
+
+  /usr/bin/du ix,
+  /usr/bin/rosversion rix,
+  @{ROS_INSTALL_BIN}/roslaunch rix,
+  @{ROS_INSTALL_LIB}/** Px,
+  @{ROS_INSTALL_SHARE}/** Px,
+  @{ROS_INSTALL}/** r,
+
+  ^/usr/bin/du {
+    owner @{ROS_LOCAL}{,/}** rw,
+
+  }
+}
+/opt/ros/kinetic/bin/rosmaster {
+  #include <ros/base>
+  #include <ros/node>
+  #include <ros/python>
+
+  @{ROS_INSTALL_BIN}/rosmaster rix,
+
+/opt/ros/kinetic/lib/rosout/rosout flags=(audit) {
+  #include <ros/base>
+  #include <ros/node>
+
+  @{ROS_INSTALL_LIB}{,/}** r,
+  /usr/lib*{,/}** r,
+  /lib*{,/}** r,
+
+  @{ROS_INSTALL_LIB}/rosout/rosout rix,
+}
+
+/opt/ros/kinetic/share/rospy_tutorials/001_talker_listener/listener.py {
+  #include <ros/base>
+  #include <ros/node>
+  #include <ros/python>
+
+  @{ROS_INSTALL_SHARE}/rospy_tutorials/001_talker_listener/listener.py r,
+
+}
+/opt/ros/kinetic/share/rospy_tutorials/001_talker_listener/talker.py {
+  #include <ros/base>
+  #include <ros/node>
+  #include <ros/python>
+
+  @{ROS_INSTALL_SHARE}/rospy_tutorials/001_talker_listener/talker.py r,
+
+}

--- a/profiles/rosmaster_talker_listener
+++ b/profiles/rosmaster_talker_listener
@@ -1,8 +1,9 @@
-# Last Modified: Wed Jun  8 11:15:22 2016
+# Last Modified: Wed Jun  8 12:14:30 2016
 #include <ros/global>
 #include <tunables/global>
 
 /opt/ros/kinetic/bin/roslaunch {
+  #include <abstractions/bash>
   #include <abstractions/python>
   #include <ros/base>
   #include <ros/node>
@@ -10,9 +11,23 @@
 
   signal send peer=@{ROS_INSTALL}/**,
 
+  /bin/dash ix,
+  /bin/netstat rix,
+  @{HOME}/* mw,
+  /proc/*/mounts r,
+  /proc/*/net/arp r,
+  /proc/*/net/dev r,
+  /proc/*/status r,
+  /sbin/ifconfig rix,
+  /sbin/ldconfig rix,
+  /sbin/ldconfig.real rix,
+  /tmp/* rmw,
   /usr/bin/du ix,
   /usr/bin/rosversion rix,
+  /usr/sbin/arp rix,
+  /var/tmp/* rmw,
   @{ROS_INSTALL_BIN}/roslaunch rix,
+  @{ROS_INSTALL_BIN}/rosmaster rix,
   @{ROS_INSTALL_LIB}/** Px,
   @{ROS_INSTALL_SHARE}/** Px,
   @{ROS_INSTALL}/** r,
@@ -29,17 +44,17 @@
 
   @{ROS_INSTALL_BIN}/rosmaster rix,
 
+}
 /opt/ros/kinetic/lib/rosout/rosout flags=(audit) {
   #include <ros/base>
   #include <ros/node>
 
-  @{ROS_INSTALL_LIB}{,/}** r,
-  /usr/lib*{,/}** r,
   /lib*{,/}** r,
-
+  /usr/lib*{,/}** r,
   @{ROS_INSTALL_LIB}/rosout/rosout rix,
-}
+  @{ROS_INSTALL_LIB}{,/}** r,
 
+}
 /opt/ros/kinetic/share/rospy_tutorials/001_talker_listener/listener.py {
   #include <ros/base>
   #include <ros/node>

--- a/profiles/rosmaster_talker_listener
+++ b/profiles/rosmaster_talker_listener
@@ -3,8 +3,6 @@
 #include <tunables/global>
 
 /opt/ros/kinetic/bin/roslaunch {
-  #include <abstractions/bash>
-  #include <abstractions/python>
   #include <ros/base>
   #include <ros/node>
   #include <ros/python>
@@ -13,25 +11,21 @@
 
   /bin/dash ix,
   /bin/netstat rix,
-  @{HOME}/* mw,
-  /proc/*/mounts r,
-  /proc/*/net/arp r,
-  /proc/*/net/dev r,
-  /proc/*/status r,
+  owner @{HOME}/* mw,
+  @{PROC}*/mounts r,
+  @{PROC}*/net/arp r,
+  @{PROC}*/net/dev r,
+  @{PROC}*/status r,
   /sbin/ifconfig rix,
-  /sbin/ldconfig rix,
-  /sbin/ldconfig.real rix,
-  /tmp/* rmw,
+  /sbin/ldconfig* rix,
   /usr/bin/du ix,
   /usr/bin/rosversion rix,
   /usr/sbin/arp rix,
-  /var/tmp/* rmw,
   @{ROS_INSTALL_BIN}/roslaunch rix,
   @{ROS_INSTALL_BIN}/rosmaster rpx,
   @{ROS_INSTALL_LIB}/** px,
   @{ROS_INSTALL_SHARE}/** px,
   @{ROS_INSTALL}/** r,
-
 
   ^/usr/bin/du {
     owner @{ROS_LOCAL}{,/}** rw,
@@ -50,10 +44,7 @@
   #include <ros/base>
   #include <ros/node>
 
-  /lib*{,/}** rix,
-  /usr/lib*{,/}** rix,
   @{ROS_INSTALL_LIB}/rosout/rosout rix,
-  @{ROS_INSTALL_LIB}{,/}** rix,
 
 }
 /opt/ros/kinetic/share/rospy_tutorials/001_talker_listener/listener.py {


### PR DESCRIPTION
Passing environment to `rosmaster` via `rpx` in roslaunch profile fixes library loading issue.
